### PR TITLE
Store synapses

### DIFF
--- a/patch/error_handler.py
+++ b/patch/error_handler.py
@@ -45,6 +45,9 @@ def catch_hoc_error(*args, **context):
 
 
 class ErrorHandler:
+    """
+
+    """
     def __init__(self, error, context):
         if not hasattr(self.__class__, "required"):
             raise ErrorHandlingError(
@@ -59,8 +62,7 @@ class ErrorHandler:
                         required_item, self.__class__.__name__
                     )
                 )
-        for context_item in context.items():
-            self.__dict__[context_item[0]] = context_item[1]
+        self.__dict__.update(context)
         self.catch(error, context)
 
     def catch(self, error, context):

--- a/patch/interpreter.py
+++ b/patch/interpreter.py
@@ -126,14 +126,12 @@ class PythonHocInterpreter:
 
           :param factory: A point process method from the HocInterpreter.
           :type factory: function
-          :param target: The Segment this point process has to be inserted into.
-          :type target: :class:`.objects.Segment`
+          :param target: The object this point process has to be inserted into.
+          :type target: :class:`.objects.PythonHocObject`
         """
+        og_target = target
         if hasattr(target, "__arc__"):
-            og_target = target
-            target = target(target.__arc__())
-            og_target.__ref__(target)
-            target.__ref__(og_target)
+            target = target(target.__arc__(), ephemeral=True)
         nrn_target = transform(target)
         point_process = factory(nrn_target, *args, **kwargs)
         pp = PointProcess(self, point_process)

--- a/patch/interpreter.py
+++ b/patch/interpreter.py
@@ -137,8 +137,8 @@ class PythonHocInterpreter:
         nrn_target = transform(target)
         point_process = factory(nrn_target, *args, **kwargs)
         pp = PointProcess(self, point_process)
-        target.__ref__(pp)
-        pp.__ref__(target)
+        og_target.__ref__(pp)
+        pp.__ref__(og_target)
         return pp
 
     def VecStim(self, pattern=None, *args, **kwargs):

--- a/patch/objects.py
+++ b/patch/objects.py
@@ -172,8 +172,13 @@ class Section(PythonHocObject, connectable):
             return recorder
         return self.recordings[x]
 
-    def synapse(self, factory, *args, **kwargs):
-        return self._interpreter.PointProcess(factory, self, *args, **kwargs)
+    def synapse(self, factory, store=False, *args, **kwargs):
+        synapse = self._interpreter.PointProcess(factory, self, *args, **kwargs)
+        if store:
+            if not hasattr(self, "synapses"):
+                self.synapses = []
+            self.synapses.append(synapse)
+        return synapse
 
     def iclamp(self, x=0.5, delay=0, duration=100, amplitude=0):
         clamp = self._interpreter.IClamp(x=x, sec=self)

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -179,7 +179,19 @@ class TestSection(unittest.TestCase):
             self.assertEqual(s2, p.cas(), "Context push should put section on stack")
         self.assertEqual(s, p.cas(), "Context exit should remove section from stack")
         self.assertRaises(RuntimeError, s2.pop)
+        # Cleanup stack after test
+        s.pop()
 
+    def test_section_synapse(self):
+        s = p.Section()
+        s.synapse(p.ExpSyn)
+        self.assertEqual(1, len(s._references), "Section.synapse call should store product.")
+        self.assertEqual(1, len(s._references[0]._references), "Section.synapse call should store reciprocal reference on product.")
+        self.assertEqual(s, s._references[0]._references[0], "Section.synapse call should store reciprocal reference on product.")
+        self.assertFalse(hasattr(s, "synapses"), "Synapse should not be stored on section unless explicitly specified.")
+        syn = s.synapse(p.ExpSyn, store=True)
+        self.assertTrue(hasattr(s, "synapses"), "Synapse should have been stored on section as it was explicitly specified.")
+        self.assertIn(syn, s.synapses, "Synapse product not found in synapse collection.")
 
 class TestPointProcess(unittest.TestCase):
     def test_factory(self):


### PR DESCRIPTION
Added keyword argument `store` to the `synapse` method of the `Section` object. When set to true it creates an attribute `synapses` and stores the synapse products inside. The synapse factory itself now uses ephemeral Segments and avoids storing a reference to them.