### PR TITLE
Users needn't use `_ref_<var>` anymore

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Black Check
-      uses: jpetrucciani/black-check@22.1.0
+      uses: jpetrucciani/black-check@21.12b0
       with:
         path: 'patch'

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Black Check
-      uses: jpetrucciani/black-check@20.8b1
+      uses: jpetrucciani/black-check@22.1.0
       with:
         path: 'patch'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 22.1.0
     hooks:
       - id: black
         language_version: python3

--- a/patch/core.py
+++ b/patch/core.py
@@ -51,7 +51,7 @@ def _is_sequence(obj):
 
 def assert_connectable(obj, label=None):
     """
-    Assert whether an object could be used as a :class:`~.objects.connectable`.
+    Assert whether an object could be used as a :class:`~.objects.Connectable`.
 
     :param label: Optional label to display to describe the object if the assertion fails.
     :type label: str

--- a/patch/objects.py
+++ b/patch/objects.py
@@ -118,16 +118,16 @@ class PythonHocObject:
         return func(*args, **kwargs)
 
 
-class connectable:
+class Connectable:
     def __init__(self):
         # Prepare a dictionary that lists which other NEURON parts this is connected to
         self._connections = {}
 
 
-class Section(PythonHocObject, connectable):
+class Section(PythonHocObject, Connectable):
     def __init__(self, *args, **kwargs):
         PythonHocObject.__init__(self, *args, **kwargs)
-        connectable.__init__(self)
+        Connectable.__init__(self)
 
     def connect(self, target, *args, **kwargs):
         """
@@ -431,16 +431,16 @@ class SEClamp(PythonHocObject):
     pass
 
 
-class NetStim(PythonHocObject, connectable):
+class NetStim(PythonHocObject, Connectable):
     def __init__(self, *args, **kwargs):
         PythonHocObject.__init__(self, *args, **kwargs)
-        connectable.__init__(self)
+        Connectable.__init__(self)
 
 
-class VecStim(PythonHocObject, connectable):
+class VecStim(PythonHocObject, Connectable):
     def __init__(self, *args, **kwargs):
         PythonHocObject.__init__(self, *args, **kwargs)
-        connectable.__init__(self)
+        Connectable.__init__(self)
 
     @property
     def vector(self):
@@ -468,10 +468,10 @@ class NetCon(PythonHocObject):
             return self.recorder
 
 
-class Segment(PythonHocObject, connectable):
+class Segment(PythonHocObject, Connectable):
     def __init__(self, interpreter, ptr, section, **kwargs):
         PythonHocObject.__init__(self, interpreter, ptr, **kwargs)
-        connectable.__init__(self)
+        Connectable.__init__(self)
         self.section = section
 
     def __netcon__(self):
@@ -481,14 +481,14 @@ class Segment(PythonHocObject, connectable):
         return self.__neuron__()._ref_v
 
 
-class PointProcess(PythonHocObject, connectable):
+class PointProcess(PythonHocObject, Connectable):
     """
     Wrapper for all point processes (membrane and synapse mechanisms).
     """
 
     def __init__(self, *args, **kwargs):
         PythonHocObject.__init__(self, *args, **kwargs)
-        connectable.__init__(self)
+        Connectable.__init__(self)
 
     def stimulate(self, pattern=None, weight=0.04, delay=0.0, **kwargs):
         """

--- a/patch/objects.py
+++ b/patch/objects.py
@@ -168,7 +168,6 @@ class WrapsPointers:
                     except:
                         is_ptr = False
                     if is_ptr:
-                        print(cls, "wrapping", k)
                         setattr(cls, k, PointerWrapper(k))
             _had_pointers_wrapped.add(hoctype)
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
         "dev": [
             "sphinx",
             "pre-commit",
-            "black>=20.8b1",
+            "black>=22.1.0",
             "sphinx-code-tabs @ git+https://github.com/Helveg/sphinx-code-tabs.git",
             "sphinx_rtd_theme",
         ]


### PR DESCRIPTION
Properties can immediately be recorded! closes #48 

Previously:

```python
v = h.Vector()
v.record(synapse._ref_ina)
```

Now:

```python
p.record(synapse.ina)
```

Whilst the values are also still usable, and even tell you at that time each one was obtained!

```
<i=0.0 at t=0.0 of <patch.objects.SEClamp object pointing to 'SEClamp[0]'>>
```